### PR TITLE
Removed the requirement for programs to be in the system PATH variable

### DIFF
--- a/aslains_scraper.py
+++ b/aslains_scraper.py
@@ -19,7 +19,7 @@ __copyright__ = 'Copyright 2019, Liam Edwards'
 __credits__ = ['Liam Edwards']
 
 __license__ = 'GNU GPL v3.0'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __maintainer__ = 'Liam Edwards'
 __email__ = 'edwardsliam77@gmail.com'
 __status__ = 'Production'

--- a/aslains_scraper.py
+++ b/aslains_scraper.py
@@ -82,12 +82,18 @@ if version_release == last_downloaded and not args.force:
 
 dl_link = tree.xpath(dlpath)[0]
 
+prog_paths = {
+    'chrome': os.path.join(os.environ['programfiles(x86)'], 'Google', 'Chrome', 'Application', 'chrome.exe'),
+    'firefox': os.path.join(os.environ['programfiles'], 'Mozilla Firefox', 'firefox.exe'),
+    'idm': os.path.join(os.environ['programfiles(x86)'], 'Internet Download Manager', 'IDMan.exe')
+}
+
 if args.program == 'chrome' or args.program == 'firefox':
-    call([args.program, dl_link])
+    call([prog_paths[args.program], dl_link])
 elif args.program == 'edge':
     call(['start', 'microsoft-edge:' + dl_link], shell=True)
 elif args.program == 'idm':
-    call(['idman', '/n', '/d', dl_link])
+    call([prog_paths[args.program], '/n', '/d', dl_link])
 elif args.program == 'other':
     if args.other is None:
         print('Invalid syntax! Please specify what program you want to use by using --other')


### PR DESCRIPTION
The script will now use the default install location for Chrome, Firefox, and IDM. If the program is not installed in it's default location, you are still required to use the `other` option.